### PR TITLE
Fix : type not declaration problem

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,2 +1,1 @@
-export { default as isEmail } from './commonjs/isEmail';
-export { default as ReactMultiEmail } from './commonjs/ReactMultiEmail';
+export * from './commonjs';

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,2 @@
+export { default as isEmail } from './commonjs/isEmail';
+export { default as ReactMultiEmail } from './commonjs/ReactMultiEmail';

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-multi-email",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "React multi email input",
   "jsnext:main": "es6/index.js",
   "main": "commonjs/index.js",


### PR DESCRIPTION
```
...
(16,33): Could not find a declaration file for module 'react-multi-email'. '.../node_modules/react-multi-email/commonjs/index.js' implicitly has an 'any' type.
  Try `npm install @types/react-multi-email` if it exists or add a new declaration (.d.ts) file containing `declare module 'react-multi-email';`
```